### PR TITLE
Added typing to passed parameters in fib.ts function

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n : number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Fib function had no typing for input number n, so adding explicit casting that it will be a number since it is passed as a string that is parsed into an int.